### PR TITLE
Depend on on mtr-nox11 instead of mtr

### DIFF
--- a/customfiles/depenguin_packages.txt
+++ b/customfiles/depenguin_packages.txt
@@ -8,7 +8,7 @@ ipmitool
 jq
 jo
 joe
-mtr
+mtr-nox11
 nano
 rsync
 smartmontools


### PR DESCRIPTION
Should get rid of a long list of dependencies