### PR TITLE
Removing umask change

### DIFF
--- a/customfiles/13_2_INSTALLERCONFIG.sample
+++ b/customfiles/13_2_INSTALLERCONFIG.sample
@@ -72,8 +72,9 @@ rm -r /etc/ssh/ssh_host_* || true
 /usr/bin/ssh-keygen -A
 service sshd restart || true
 
+# removed as causing problems with user-run Ruby programs in jails
 # Change umask
-sed -i '' -e 's/:umask=022:/:umask=027:/g' /etc/login.conf
+#sed -i '' -e 's/:umask=022:/:umask=027:/g' /etc/login.conf
 
 # Disable sendmail
 sysrc sendmail_enable=NONE

--- a/customfiles/13_2_INSTALLERCONFIG.sample
+++ b/customfiles/13_2_INSTALLERCONFIG.sample
@@ -74,7 +74,7 @@ service sshd restart || true
 
 # removed as causing problems with user-run Ruby programs in jails
 # Change umask
-#sed -i '' -e 's/:umask=022:/:umask=027:/g' /etc/login.conf
+# sed -i '' -e 's/:umask=022:/:umask=027:/g' /etc/login.conf
 
 # Disable sendmail
 sysrc sendmail_enable=NONE

--- a/customfiles/14_0_INSTALLERCONFIG.sample
+++ b/customfiles/14_0_INSTALLERCONFIG.sample
@@ -72,8 +72,9 @@ rm -r /etc/ssh/ssh_host_* || true
 /usr/bin/ssh-keygen -A
 service sshd restart || true
 
+# removed as causing problems with user-run Ruby programs in jails
 # Change umask
-sed -i '' -e 's/:umask=022:/:umask=027:/g' /etc/login.conf
+# sed -i '' -e 's/:umask=022:/:umask=027:/g' /etc/login.conf
 
 # Disable sendmail
 sysrc sendmail_enable=NONE


### PR DESCRIPTION
Remove a hardening step which changes umask from 022 to 027 in login.conf

This causes problems with user-run Ruby programs needing network resolution. They can't read /etc/resolv.conf in jails because permissions are 640.