### PR TITLE
Newer AX41 Servers might come with re0 interfaces, detect the uplink accordingly on firstboot

### DIFF
--- a/customfiles/14_0_INSTALLERCONFIG.sample
+++ b/customfiles/14_0_INSTALLERCONFIG.sample
@@ -152,7 +152,7 @@ cat >>/usr/local/etc/rc.d/firstboot_depenguin<<"EOF"
 : ${firstboot_depenguin_enable:="NO"}
 : ${firstboot_depenguin_uplink_name:="untrusted"}
 : ${firstboot_depenguin_interfaces:="vtnet0 \
-    em0 em1 igb0 igb1 bge0 bge1 ixl0 ixl1"}
+    em0 em1 igb0 igb1 bge0 bge1 ixl0 ixl1 re0 re1"}
 : ${firstboot_depenguin_sleep_secs:="10"}
 
 name="firstboot_depenguin"


### PR DESCRIPTION
Otherwise the `firstboot` rc-script will not find an uplink and network will be broken upon reboot.