### PR TITLE
Add `bnxt` and `bxe` Interfaces

### DIFF
--- a/customfiles/14_0_INSTALLERCONFIG.sample
+++ b/customfiles/14_0_INSTALLERCONFIG.sample
@@ -157,7 +157,7 @@ cat >>/usr/local/etc/rc.d/firstboot_depenguin<<"EOF"
 : ${firstboot_depenguin_enable:="NO"}
 : ${firstboot_depenguin_uplink_name:="untrusted"}
 : ${firstboot_depenguin_interfaces:="vtnet0 \
-    em0 em1 igb0 igb1 bge0 bge1 ixl0 ixl1 re0 re1"}
+    em0 em1 igb0 igb1 bge0 bge1 ixl0 ixl1 re0 re1 bnxt0 bnxt1 bxe0 bxe1"}
 : ${firstboot_depenguin_sleep_secs:="10"}
 
 name="firstboot_depenguin"


### PR DESCRIPTION
They are used in some 10G configurations at hetzner. Notably the AX 162.