### PR TITLE
Add Support for 10G Intel Cards

### DIFF
--- a/customfiles/14_0_INSTALLERCONFIG.sample
+++ b/customfiles/14_0_INSTALLERCONFIG.sample
@@ -214,6 +214,7 @@ firstboot_depenguin_run()
 	sleep "${sleep_secs}"
 	for intf in $firstboot_depenguin_interfaces; do
 		echo "$intfs" | grep -Eq "^${intf}$" || continue
+                ifconfig "$intf" up
 		if ifconfig "$intf" | grep -q "status: no carrier"; then
 			echo "Interface ${intf} has no carrier"
 			continue

--- a/customfiles/14_0_INSTALLERCONFIG.sample
+++ b/customfiles/14_0_INSTALLERCONFIG.sample
@@ -157,7 +157,8 @@ cat >>/usr/local/etc/rc.d/firstboot_depenguin<<"EOF"
 : ${firstboot_depenguin_enable:="NO"}
 : ${firstboot_depenguin_uplink_name:="untrusted"}
 : ${firstboot_depenguin_interfaces:="vtnet0 \
-    em0 em1 igb0 igb1 ix0 ix1 ix2 ix3 bge0 bge1 ixl0 ixl1 re0 re1 bnxt0 bnxt1 bxe0 bxe1"}
+    em0 em1 igb0 igb1 ix0 ix1 ix2 ix3 bge0 bge1 ixl0 ixl1 re0 re1 \
+    bnxt0 bnxt1 bxe0 bxe1"}
 : ${firstboot_depenguin_sleep_secs:="10"}
 
 name="firstboot_depenguin"

--- a/customfiles/14_0_INSTALLERCONFIG.sample
+++ b/customfiles/14_0_INSTALLERCONFIG.sample
@@ -214,6 +214,8 @@ firstboot_depenguin_run()
 	sleep "${sleep_secs}"
 	for intf in $firstboot_depenguin_interfaces; do
 		echo "$intfs" | grep -Eq "^${intf}$" || continue
+        	if echo "$intf" | grep -Eq "ix"; then
+			ifconfig $intf up
                 ifconfig "$intf" up
 		if ifconfig "$intf" | grep -q "status: no carrier"; then
 			echo "Interface ${intf} has no carrier"

--- a/customfiles/14_0_INSTALLERCONFIG.sample
+++ b/customfiles/14_0_INSTALLERCONFIG.sample
@@ -216,6 +216,7 @@ firstboot_depenguin_run()
 		echo "$intfs" | grep -Eq "^${intf}$" || continue
         	if echo "$intf" | grep -Eq "ix"; then
 			ifconfig $intf up
+		fi
 		if ifconfig "$intf" | grep -q "status: no carrier"; then
 			echo "Interface ${intf} has no carrier"
 			continue

--- a/customfiles/14_0_INSTALLERCONFIG.sample
+++ b/customfiles/14_0_INSTALLERCONFIG.sample
@@ -157,7 +157,7 @@ cat >>/usr/local/etc/rc.d/firstboot_depenguin<<"EOF"
 : ${firstboot_depenguin_enable:="NO"}
 : ${firstboot_depenguin_uplink_name:="untrusted"}
 : ${firstboot_depenguin_interfaces:="vtnet0 \
-    em0 em1 igb0 igb1 bge0 bge1 ixl0 ixl1 re0 re1 bnxt0 bnxt1 bxe0 bxe1"}
+    em0 em1 igb0 igb1 ix0 ix1 bge0 bge1 ixl0 ixl1 re0 re1 bnxt0 bnxt1 bxe0 bxe1"}
 : ${firstboot_depenguin_sleep_secs:="10"}
 
 name="firstboot_depenguin"

--- a/customfiles/14_0_INSTALLERCONFIG.sample
+++ b/customfiles/14_0_INSTALLERCONFIG.sample
@@ -215,9 +215,7 @@ firstboot_depenguin_run()
 	sleep "${sleep_secs}"
 	for intf in $firstboot_depenguin_interfaces; do
 		echo "$intfs" | grep -Eq "^${intf}$" || continue
-        	if echo "$intf" | grep -Eq "ix"; then
-			ifconfig $intf up
-		fi
+        	echo "$intf" | grep -Eq "^ix[0-9]$" && ifconfig "$intf" up
 		if ifconfig "$intf" | grep -q "status: no carrier"; then
 			echo "Interface ${intf} has no carrier"
 			continue

--- a/customfiles/14_0_INSTALLERCONFIG.sample
+++ b/customfiles/14_0_INSTALLERCONFIG.sample
@@ -157,7 +157,7 @@ cat >>/usr/local/etc/rc.d/firstboot_depenguin<<"EOF"
 : ${firstboot_depenguin_enable:="NO"}
 : ${firstboot_depenguin_uplink_name:="untrusted"}
 : ${firstboot_depenguin_interfaces:="vtnet0 \
-    em0 em1 igb0 igb1 ix0 ix1 bge0 bge1 ixl0 ixl1 re0 re1 bnxt0 bnxt1 bxe0 bxe1"}
+    em0 em1 igb0 igb1 ix0 ix1 ix2 ix3 bge0 bge1 ixl0 ixl1 re0 re1 bnxt0 bnxt1 bxe0 bxe1"}
 : ${firstboot_depenguin_sleep_secs:="10"}
 
 name="firstboot_depenguin"

--- a/customfiles/14_0_INSTALLERCONFIG.sample
+++ b/customfiles/14_0_INSTALLERCONFIG.sample
@@ -216,7 +216,6 @@ firstboot_depenguin_run()
 		echo "$intfs" | grep -Eq "^${intf}$" || continue
         	if echo "$intf" | grep -Eq "ix"; then
 			ifconfig $intf up
-                ifconfig "$intf" up
 		if ifconfig "$intf" | grep -q "status: no carrier"; then
 			echo "Interface ${intf} has no carrier"
 			continue


### PR DESCRIPTION
Hi! 

this network card is found in many off-the-shelf servers and I'm currently deploying servers on leaseweb, which have this card. 

They additionally also have Broadcom-cards, but they are plugged into the private net. That means there is an uplink detected, but its not public. That is why I put the Intel cards before the broadcom-cards. 

I'll open another pull request with the neccessary changes to `depenguinme.sh` to support leasewebs rescue-version of debian, so we can slowly add support for more providers/rescue systems/network cards.

Cheers